### PR TITLE
Use couchdb-bootstrap to configure Couch

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+# EditorConfig is awesome: http://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+trim_trailing_whitespace = true
+insert_final_newline = true
+indent_style = space
+indent_size = 2
+

--- a/.kitchen.cloud.yml
+++ b/.kitchen.cloud.yml
@@ -27,6 +27,7 @@ suites:
     run_list:
       - recipe[btc-infrastructure::default]
       - recipe[btc-infrastructure::couchdb]
+      - recipe[btc-infrastructure::couchdb_bootstrap]
     attributes:
       admin_users:
         - username: "admin_username"

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -21,6 +21,7 @@ suites:
     run_list:
       - recipe[btc-infrastructure::default]
       - recipe[btc-infrastructure::couchdb]
+      - recipe[btc-infrastructure::couchdb_bootstrap]
     attributes:
       admin_users:
         - username: "admin_username"

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,8 +1,12 @@
 
 # <> Directory at which to store installer files
 normal['installers']['dir'] = 'C:\Installers'
+
 # <> Directory at which to store application files
 normal['server']['dir'] = 'C:\App-Server'
+
+# <> Directory in which to perform other work related to chef
+normal['work']['dir'] = 'C:\Work'
 
 # <> Array of admin users as {:username, :password} hashes
 default['admin_users'] = []

--- a/files/default/couchdb/points/_design/doc_deletion/language
+++ b/files/default/couchdb/points/_design/doc_deletion/language
@@ -1,0 +1,1 @@
+javascript

--- a/files/default/couchdb/points/_design/doc_deletion/validate_doc_update.js
+++ b/files/default/couchdb/points/_design/doc_deletion/validate_doc_update.js
@@ -1,0 +1,8 @@
+function(newDoc, oldDoc, userCtx, secObj) {
+  if(newDoc._deleted) {
+    var admin = userCtx.roles.indexOf('_admin') > -1;
+    if(!admin) {
+      throw({ 'forbidden': 'Only admins may delete documents' });
+    }
+  }
+}

--- a/files/default/couchdb/points/_design/doc_id/language
+++ b/files/default/couchdb/points/_design/doc_id/language
@@ -1,0 +1,1 @@
+javascript

--- a/files/default/couchdb/points/_design/doc_id/validate_doc_update.js
+++ b/files/default/couchdb/points/_design/doc_id/validate_doc_update.js
@@ -1,0 +1,12 @@
+function(newDoc, oldDoc, userCtx, secObj) {
+  var admin = userCtx.roles.indexOf('_admin') > -1;
+  if(newDoc._deleted) {
+    return;
+  } else if(admin) {
+    return;
+  } else if(newDoc._id.match(/^point\/.*/)) {
+    return;
+  } else {
+    throw({ 'forbidden': 'Document ids must begin with `point/`'});
+  }
+}

--- a/recipes/couchdb.rb
+++ b/recipes/couchdb.rb
@@ -37,9 +37,11 @@ powershell_script 'install_couchdb' do
   action :run
 end
 
-# Copy over our CouchDB config.
-# TODO: Transition to couchdb-bootstrap, an npm package
-template "#{home}/etc/couchdb/local.ini" do
+template_path = "#{home}/etc/couchdb/local.ini"
+template_resource = "template[#{template_path}]"
+
+# Copy over our CouchDB credentials and other config.
+template template_path do
   source 'local.ini.erb'
 end
 
@@ -78,4 +80,5 @@ end
 
 windows_service 'Apache CouchDB' do
   action :start
+  subscribes :restart, template_resource, :immediately
 end

--- a/recipes/couchdb.rb
+++ b/recipes/couchdb.rb
@@ -37,11 +37,8 @@ powershell_script 'install_couchdb' do
   action :run
 end
 
-template_path = "#{home}/etc/couchdb/local.ini"
-template_resource = "template[#{template_path}]"
-
 # Copy over our CouchDB credentials and other config.
-template template_path do
+template "#{home}/etc/couchdb/local.ini" do
   source 'local.ini.erb'
 end
 

--- a/recipes/couchdb.rb
+++ b/recipes/couchdb.rb
@@ -79,6 +79,5 @@ windows_service 'Apache CouchDB' do
 end
 
 windows_service 'Apache CouchDB' do
-  action :start
-  subscribes :restart, template_resource, :immediately
+  action :restart
 end

--- a/recipes/couchdb_bootstrap.rb
+++ b/recipes/couchdb_bootstrap.rb
@@ -30,10 +30,7 @@ powershell_script 'install_couchdb_bootstrap' do
   code 'npm install -g --silent couchdb-bootstrap'
   cwd "#{work}/couchdb"
   action :run
-  not_if <<-EOH
-  Test-Path ( [Environment]::GetFolderPath('ApplicationData') + `
-    '/npm/couchdb-bootstrap.cmd' )
-  EOH
+  not_if 'Get-Command couchdb-bootstrap'
 end
 
 admin = node['admin_users'][0]
@@ -45,12 +42,7 @@ port = node['couchdb']['port']
 # Run couchdb-bootstrap on our folder structure.
 # TODO: Figure out better npm path solution
 powershell_script 'bootstrap' do
-  code <<-EOH
-  $npm = [Environment]::GetFolderPath('ApplicationData') + '/npm'
-  $env:Path += ';' + $npm
-
-  couchdb-bootstrap http://#{username}:#{password}@localhost:#{port}
-  EOH
+  code "couchdb-bootstrap http://#{username}:#{password}@localhost:#{port}"
   cwd "#{work}/couchdb"
   action :run
 end

--- a/recipes/couchdb_bootstrap.rb
+++ b/recipes/couchdb_bootstrap.rb
@@ -1,0 +1,56 @@
+# Cookbook Name:: btc-infrastructure
+# Recipe:: couchdb_bootstrap
+#
+# Author:: Steven Kroh (<sk.kroh@gmail.com>)
+#
+# Copyright 2016, Adventure Cycling Association
+
+# <
+# Bootstraps our running CouchDB instance with design documents and other
+# settings
+# >
+
+# We need nodejs to run couchdb-bootstrap: it's an npm module
+include_recipe 'btc-infrastructure::nodejs'
+
+work = node['work']['dir']
+
+# Create a work directory to extract our CouchDB config structure to
+directory work
+
+remote_directory "#{work}/couchdb" do
+  source 'couchdb'
+  action :create
+end
+
+# Install the couchdb-bootstrap npm module globally
+# TODO: Figure out better npm path solution.
+# The not_if should really just be `Get-Command couchdb-bootstrap`
+powershell_script 'install_couchdb_bootstrap' do
+  code 'npm install -g --silent couchdb-bootstrap'
+  cwd "#{work}/couchdb"
+  action :run
+  not_if <<-EOH
+  Test-Path ( [Environment]::GetFolderPath('ApplicationData') + `
+    '/npm/couchdb-bootstrap.cmd' )
+  EOH
+end
+
+admin = node['admin_users'][0]
+username = admin['username']
+password = admin['password']
+
+port = node['couchdb']['port']
+
+# Run couchdb-bootstrap on our folder structure.
+# TODO: Figure out better npm path solution
+powershell_script 'bootstrap' do
+  code <<-EOH
+  $npm = [Environment]::GetFolderPath('ApplicationData') + '/npm'
+  $env:Path += ';' + $npm
+
+  couchdb-bootstrap http://#{username}:#{password}@localhost:#{port}
+  EOH
+  cwd "#{work}/couchdb"
+  action :run
+end

--- a/recipes/nodejs.rb
+++ b/recipes/nodejs.rb
@@ -32,6 +32,4 @@ windows_package 'Node.js' do
 end
 
 # Need to correct the Chef process for the rest of our run
-if !ENV['Path'].match(/nodejs/)
-  ENV['Path'] += ';C:\\Program Files\\nodejs\\'
-end
+ENV['Path'] += ';C:/Program Files/nodejs/' unless ENV['Path'] =~ /nodejs/

--- a/recipes/nodejs.rb
+++ b/recipes/nodejs.rb
@@ -25,7 +25,13 @@ remote_file "#{installers}/#{node_msi}" do
   action :create
 end
 
+# Install Node.js to Program Files and update Path
 windows_package 'Node.js' do
   source "#{installers}/#{node_msi}"
   action :install
+end
+
+# Need to correct the Chef process for the rest of our run
+if !ENV['Path'].match(/nodejs/)
+  ENV['Path'] += ';C:\\Program Files\\nodejs\\'
 end

--- a/recipes/nodejs.rb
+++ b/recipes/nodejs.rb
@@ -14,8 +14,6 @@ Installs Node.js, including npm. Git is also installed, at version
 
 installers = node['installers']['dir']
 
-include_recipe 'git::windows'
-
 node_url = node['nodejs']['url']
 node_msi = node['nodejs']['msi']
 
@@ -31,5 +29,10 @@ windows_package 'Node.js' do
   action :install
 end
 
-# Need to correct the Chef process for the rest of our run
-ENV['Path'] += ';C:/Program Files/nodejs/' unless ENV['Path'] =~ /nodejs/
+windows_path 'C:\\Program Files\\nodejs' do
+  action :add
+end
+
+windows_path '%AppData%\\npm' do
+  action :add
+end

--- a/recipes/nodejs_deploy.rb
+++ b/recipes/nodejs_deploy.rb
@@ -6,6 +6,8 @@
 #
 # Copyright 2016, Adventure Cycling Association
 
+include_recipe 'git::windows'
+
 server_dir = node['server']['dir']
 directory server_dir
 

--- a/templates/default/local.ini.erb
+++ b/templates/default/local.ini.erb
@@ -4,104 +4,17 @@
 ; in default.ini, but unlike changes made to default.ini, this file won't be
 ; overwritten on server upgrade.
 
-[couchdb]
-;max_document_size = 4294967296 ; bytes
-
 [httpd]
 port = <%= node.couchdb.port %>
 bind_address = <%= node.couchdb.bind_address %>
-
 enable_cors = true
 
-``
-; Options for the MochiWeb HTTP server.
-;server_options = [{backlog, 128}, {acceptor_pool_size, 16}]
-; For more socket options, consult Erlang's module 'inet' man page.
-;socket_options = [{recbuf, 262144}, {sndbuf, 262144}, {nodelay, true}]
-
-; Uncomment next line to trigger basic-auth popup on unauthorized requests.
-;WWW-Authenticate = Basic realm="administrator"
-
-; Uncomment next line to set the configuration modification whitelist. Only
-; whitelisted values may be changed via the /_config URLs. To allow the admin
-; to change this value over HTTP, remember to include {httpd,config_whitelist}
-; itself. Excluding it from the list would require editing this file to update
-; the whitelist.
-;config_whitelist = [{httpd,config_whitelist}, {log,level}, {etc,etc}]
-
 [cors]
+headers = accept,authorization,content-type,origin,referer,x-csrf-token
+methods = GET,PUT,POST,HEAD,DELETE
 credentials = true
 origins = *
-methods = GET, PUT, POST, HEAD, DELETE
-headers = accept, authorization, content-type, origin, referer
 
-[query_servers]
-;nodejs = /usr/local/bin/couchjs-node /path/to/couchdb/share/server/main.js
-
-
-[httpd_global_handlers]
-;_google = {couch_httpd_proxy, handle_proxy_req, <<"http://www.google.com">>}
-
-[couch_httpd_auth]
-; If you set this to true, you should also uncomment the WWW-Authenticate line
-; above. If you don't configure a WWW-Authenticate header, CouchDB will send
-; Basic realm="server" in order to prevent you getting logged out.
-; require_valid_user = false
-
-[log]
-;level = debug
-
-[log_level_by_module]
-; In this section you can specify any of the four log levels 'none', 'info',
-; 'error' or 'debug' on a per-module basis. See src/*/*.erl for various
-; modules.
-;couch_httpd = error
-
-[os_daemons]
-; For any commands listed here, CouchDB will attempt to ensure that
-; the process remains alive. Daemons should monitor their environment
-; to know when to exit. This can most easily be accomplished by exiting
-; when stdin is closed.
-;foo = /path/to/command -with args
-
-[daemons]
-; enable SSL support by uncommenting the following line and supply the PEM's below.
-; the default ssl port CouchDB listens on is 6984
-; httpsd = {couch_httpd, start_link, [https]}
-
-[ssl]
-;cert_file = /full/path/to/server_cert.pem
-;key_file = /full/path/to/server_key.pem
-;password = somepassword
-; set to true to validate peer certificates
-verify_ssl_certificates = false
-; Path to file containing PEM encoded CA certificates (trusted
-; certificates used for verifying a peer certificate). May be omitted if
-; you do not want to verify the peer.
-;cacert_file = /full/path/to/cacertf
-; The verification fun (optional) if not specified, the default
-; verification fun will be used.
-;verify_fun = {Module, VerifyFun}
-; maximum peer certificate depth
-ssl_certificate_max_depth = 1
-
-; To enable Virtual Hosts in CouchDB, add a vhost = path directive. All requests to
-; the Virual Host will be redirected to the path. In the example below all requests
-; to http://example.com/ are redirected to /database.
-; If you run CouchDB on a specific port, include the port number in the vhost:
-; example.com:5984 = /database
-[vhosts]
-;example.com = /database/
-
-[update_notification]
-;unique notifier name=/full/path/to/exe -with "cmd line arg"
-
-; To create an admin account uncomment the '[admins]' section below and add a
-; line in the format 'username = password'. When you next start CouchDB, it
-; will change the password to a hash (so that your passwords don't linger
-; around in plain-text files). You can add more admin accounts with more
-; 'username = password' lines. Don't forget to restart CouchDB after
-; changing this.
 [admins]
 <% node.admin_users.each do |admin_user| -%>
 <%= admin_user[:username] %> = <%= admin_user[:password] %>

--- a/test/integration/default/rspec/Gemfile
+++ b/test/integration/default/rspec/Gemfile
@@ -1,0 +1,4 @@
+source 'https://rubygems.org'
+
+gem 'rspec'
+gem 'rspec-api'

--- a/test/integration/default/rspec/couchdb_bootstrap_spec.rb
+++ b/test/integration/default/rspec/couchdb_bootstrap_spec.rb
@@ -1,0 +1,36 @@
+
+require 'rspec'
+require 'rspec-api'
+
+# Ensure we've created the points database
+describe 'CouchDB points database' do
+  resource :points do
+    host 'http://localhost:5984'
+
+    has_attribute :db_name, type: :string
+
+    get '/points', collection: false do
+      respond_with :ok
+    end
+  end
+end
+
+# Ensure the admin account has been setup.
+# The username and password should match .kitchen.yaml
+resource :config do
+  describe 'Those who are authenticated' do
+    host 'http://admin_username:admin_password@localhost:5984'
+
+    get '/_config', colection: false do
+      respond_with :ok
+    end
+  end
+
+  describe 'Those who are not authenticated' do
+    host 'http://localhost:5984'
+
+    get '/_config', collection: false do
+      respond_with :unauthorized
+    end
+  end
+end

--- a/test/integration/default/rspec/spec_helper.rb
+++ b/test/integration/default/rspec/spec_helper.rb
@@ -1,0 +1,6 @@
+
+require 'rspec'
+
+RSpec.configure do |config|
+  config.add_formatter 'documentation'
+end

--- a/test/integration/nodejs/serverspec/git_spec.rb
+++ b/test/integration/nodejs/serverspec/git_spec.rb
@@ -4,6 +4,8 @@ set :backend, :cmd
 set :os, family: 'windows'
 
 describe 'Git Version Control System' do
+  before { skip 'Ignoring Git tests because nodejs_deploy is disabled' }
+
   # On Windows, the package name is the DisplayName in the registry
   describe package('Git version 2.7.0') do
     it { should be_installed }


### PR DESCRIPTION
This allows us to define our design documents in real javascript files.
The new bootstrap install is tested with busser-rspec.
