### PR TITLE
Install git using custom Inno Setup script

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -27,20 +27,8 @@ suites:
 - name: nodejs
   run_list:
     - recipe[btc-infrastructure::default]
+    - recipe[btc-infrastructure::git]
     - recipe[btc-infrastructure::nodejs]
     - recipe[btc-infrastructure::nodejs_deploy]
   data_bags_path: "test/integration/data_bags"
-  # attributes:
-  #   deploy:
-  #     btc-app-server:
-  #       application: btc-app-server
-  #       deploy_to: es5\src\index.js
-  #       scm:
-  #         password: null
-  #         repository: https://s3.amazonaws.com/btc-app-server/btc-app-server-latest.tgz
-  #         revision: null
-  #         scm_type: s3
-  #       environment_variables:
-  #         NODE_ENV: production
-  #         SERVER_SECRET: secret
-  #         SERVER_JWT_EXP: 20m
+  

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Configures Windows Server instances to run the Bicycle Touring Companion applica
 * btc-infrastructure::couchdb
 * btc-infrastructure::couchdb_bootstrap
 * btc-infrastructure::default
+* btc-infrastructure::git
 * btc-infrastructure::nodejs
 * btc-infrastructure::nodejs_deploy
 

--- a/attributes/git.rb
+++ b/attributes/git.rb
@@ -1,0 +1,18 @@
+
+release = 'v2.7.1.windows.2'
+git_version = '2.7.1.2'
+
+hash = '956417448441e267a0ca601f47a2cd346e2d09589673060ae25d66628b2abc82'
+
+normal['git']['version'] = git_version
+
+# DisplayName of Git in the registry, for idempotency
+normal['git']['display_name'] = "Git version #{git_version}"
+
+url = "https://github.com/git-for-windows/git/releases/download/#{release}"
+exe = "Git-#{git_version}-64-bit.exe"
+
+normal['git']['url'] = url
+normal['git']['exe'] = exe
+normal['git']['checksum'] = hash
+normal['git']['home'] = 'C:\\Program Files\\Git'

--- a/recipes/git.rb
+++ b/recipes/git.rb
@@ -1,0 +1,43 @@
+# Cookbook Name:: btc-infrastructure
+# Recipe:: git
+#
+# Author:: Steven Kroh
+#
+# Copyright 2016, Adventure Cycling Association
+
+git_url = node['git']['url']
+git_exe = node['git']['exe']
+
+file_cache_path = Chef::Config[:file_cache_path]
+
+remote_file File.join(file_cache_path, git_exe) do
+  source "#{git_url}/#{git_exe}"
+  checksum node['git']['checksum']
+  action :create
+end
+
+installer_script = File.join(file_cache_path, 'git.iss')
+
+template installer_script do
+  source 'git.iss.erb'
+end
+
+git_home = node['git']['home']
+
+# Install Node.js to Program Files
+windows_package node['git']['display_name'] do
+  source File.join(file_cache_path, git_exe)
+  options "/LOADINF='#{installer_script}'"
+  action :install
+end
+
+# On some systems, the 64 bit installer sets an x86 path variable
+# We do not want that!
+windows_path 'C:\\Program Files (x86)\\Git\\bin' do
+  action :remove
+end
+
+# Add Git's home directory to the Windows path, and to Ruby's ENV
+windows_path "#{git_home}\\bin" do
+  action [:remove, :add]
+end

--- a/test/integration/nodejs/serverspec/git_spec.rb
+++ b/test/integration/nodejs/serverspec/git_spec.rb
@@ -1,0 +1,11 @@
+require 'serverspec'
+
+set :backend, :cmd
+set :os, family: 'windows'
+
+describe 'Git Package' do
+  # On Windows, the package name is the DisplayName in the registry
+  describe package('Git version 2.7.1.2') do
+    it { should be_installed }
+  end
+end


### PR DESCRIPTION
Until backbone-pouch v1.5.0 is uploaded to npm, we need git installed on the app server so we can install the dependency from GitHub.
