### PR TITLE
Add configure recipe for btc-app-server

### DIFF
--- a/Berksfile.lock
+++ b/Berksfile.lock
@@ -4,7 +4,7 @@ DEPENDENCIES
     metadata: true
 
 GRAPH
-  btc-infrastructure (0.3.4)
+  btc-infrastructure (0.4.0)
     netsh_firewall (>= 0.3.2)
     nssm (~> 1.2.0)
   chef_handler (1.2.0)

--- a/metadata.rb
+++ b/metadata.rb
@@ -3,7 +3,7 @@ maintainer       'Adventure Cycling Association'
 maintainer_email 'sk.kroh@gmail.com'
 license          'AGPL v3'
 description      'Installs and configures Bicycle Touring Companion'
-version          '0.3.4'
+version          '0.4.0'
 
 source_url       'https://github.com/bikelomatic-complexity/btc-infrastructure'
 issues_url       'https://github.com/bikelomatic-complexity/btc-infrastructure/issues'

--- a/recipes/nodejs_configure.rb
+++ b/recipes/nodejs_configure.rb
@@ -1,0 +1,57 @@
+#
+# Cookbook Name:: btc-infrastructure
+# Recipe:: nodejs_configure
+#
+# Author:: Steven Kroh
+#
+# Copyright 2016, Adventure Cycling Association
+
+log 'configuring an application layer instance'
+
+stack = search('aws_opsworks_stack').first
+stack_name = stack['name']
+
+log "stack name: #{stack_name}"
+
+database_layer = search('aws_opsworks_layer', 'shortname:database').first
+id = database_layer['layer_id']
+
+log "database layer id: #{id}"
+
+# Start by assuming there is not databsase server instance to connect to
+domain = false
+
+# The development stack only supports a single database server instance.
+# In this case, connect to it via its private ip. The database server will
+# permit connections by security group rule.
+if stack_name.include? 'dev'
+  instance = search('aws_opsworks_instance', "layer_ids:#{id}").first
+  domain = instance['private_ip'] if instance
+# The production and staging stacks manage multiple database servers behind
+# an elastic load balancer. Connect by the ELB's dns name.
+else
+  elb = search('aws_opsworks_elastic_load_balancer', "layer_id:#{id}").first
+  domain = elb['dns_name'] if elb
+end
+
+# If there is a database server, set SERVER_COUCH_DOMAIN. Otherwise, unset
+# the variable. Unsetting the variable will cause the api service
+if domain
+  log "database server domain: #{domain}"
+
+  env 'SERVER_COUCH_DOMAIN' do
+    value domain
+    action :create
+  end
+else
+  log 'database server domain: NA'
+
+  env 'SERVER_COUCH_DOMAIN' do
+    action :delete
+  end
+end
+
+# Restart the service to pull in the modified environment variable
+windows_service node['server']['name'] do
+  action :restart
+end

--- a/recipes/nodejs_deploy.rb
+++ b/recipes/nodejs_deploy.rb
@@ -25,17 +25,17 @@ if app && app['deploy'] == true
     action :allow
   end
 
-  # Ensure the app server pulls the production configuration
-  env 'NODE_ENV' do
-    value app['environment']['NODE_ENV']
-  end
-
-  env 'SERVER_SECRET' do
-    value app['environment']['SERVER_SECRET']
-  end
-
-  env 'SERVER_JWT_EXP' do
-    value app['environment']['SERVER_JWT_EXP']
+  # Set all environment variables incoming from the app. These include, but
+  # are not limited to:
+  #  - NODE_ENV
+  #  - SERVER_SECRET
+  #  - SERVER_JWT_EXP
+  #  - SERVER_COUCH_USERNAME
+  #  - SERVER_COUCH_PASSWORD
+  app['environment'].each do |key, val|
+    env key do
+      value val
+    end
   end
 
   # The app servers' directory in the global node_modules

--- a/test/integration/data_bags/aws_opsworks_app/btc_app_server.json
+++ b/test/integration/data_bags/aws_opsworks_app/btc_app_server.json
@@ -8,7 +8,7 @@
     "user": null
   },
   "attributes": {
-    "document_root": "es5/src/index.js"
+    "document_root": "lib/index.js"
   },
   "domains": [
     "btc_app_server"


### PR DESCRIPTION
During the configure life-cycle event, AWS OpsWorks will call the nodejs_configure.rb recipe. We use this opportunity to connect the btc-app-server to the database server.

In the development stack, there will be only one database server instance. Therefore, we find the single instance in the database stack and connect it's private IP address to the btc-app-server (via SERVER_COUCH_DOMAIN).

In any other stack, we expect to have a load balancer attached to the database layer. So, find that ELB and connect it's domain name to the btc-app-server (again, via SERVER_COUCH_DOMAIN)
